### PR TITLE
Expose a version flag in the CLI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag = True
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:tox_server/__init__.py]
+[bumpversion:file:tox_server/__about__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,3 +324,12 @@ def test_cli_loglevel() -> None:
 
     result = runner.invoke(cmd, ["--level", "foo"])
     assert result.exit_code == 2
+
+
+def test_cli_version() -> None:
+
+    runner = click.testing.CliRunner()
+
+    result = runner.invoke(cli.main, "--version")
+    assert result.exit_code == 0
+    assert "version" in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py37,py38
 [testenv]
 deps =
     -rrequirements/test-requirements.txt
+    py37: mock
 commands = pytest --cov-config={toxinidir}/setup.cfg --cov-append {posargs} {env:PYTEST_ARGS}
 setenv =
     PYTEST_ARGS=

--- a/tox_server/__about__.py
+++ b/tox_server/__about__.py
@@ -1,0 +1,2 @@
+__author__ = "Alex Rudy"
+__version__ = "0.5.0"

--- a/tox_server/__init__.py
+++ b/tox_server/__init__.py
@@ -1,8 +1,7 @@
 from . import cli
 from . import client
 from . import server
+from .__about__ import __version__  # noqa: F401
 from .cli import main
 
 __all__ = ["server", "client", "cli", "main"]
-
-__version__ = "0.5.0"

--- a/tox_server/cli.py
+++ b/tox_server/cli.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import click
 
+from .__about__ import __version__
 from .client import init_click_group as init_client_commands
 from .server import serve
 
@@ -58,6 +59,7 @@ class LogLevelParamType(click.ParamType):
     help="Set logging level",
     default=logging.WARNING,
 )
+@click.version_option(version=__version__)
 @click.pass_context
 def main(ctx: click.Context, host: str, port: int, bind_host: str, timeout: Optional[float], log_level: int) -> None:
     """Interact with a tox server."""


### PR DESCRIPTION
Support —version, and move the programatic version flag to `__about__`