### PR TITLE
Delay queued notification message

### DIFF
--- a/tox_server/cli.py
+++ b/tox_server/cli.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any
 from typing import Optional
 
@@ -68,6 +69,7 @@ def main(ctx: click.Context, host: str, port: int, bind_host: str, timeout: Opti
     cfg["uri"] = f"tcp://{host}:{port:d}"
     cfg["bind"] = f"tcp://{bind_host}:{port:d}"
     cfg["timeout"] = timeout
+    cfg["timeout_for_queue_notification"] = float(os.environ.get("_TOX_SERVER_TIMEOUT_FOR_QUEUE_NOTIFICATION", "2.0"))
     logging.basicConfig(format=f"[{ctx.invoked_subcommand}] %(message)s", level=log_level)
 
 


### PR DESCRIPTION
The client aggressively prints “Command RUN is queued” when it recieves a heartbeat quickly but the command is still in the queued state. This happens regardless of whether there is anything else in the queue, so its kind of a noisy red-herring. This PR delays the appearance of that messge.